### PR TITLE
test: add comparison benchmark to activerecord-session_store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 /.bundle/
 /coverage/
 /doc/
-/log/*.log
+/log/*.log*
 /pkg/
 /tmp/
 /test/dummy/db/*.sqlite3
 /test/dummy/db/*.sqlite3-*
-/test/dummy/log/*.log
+/test/dummy/log/*.log*
 /test/dummy/storage/
 /test/dummy/tmp/

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,9 @@ gem "sqlite3"
 
 gem "bootsnap", require: false
 
+# For performance benchmarking
+gem "activerecord-session_store"
+
 group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 
@@ -28,7 +31,10 @@ group :development do
 end
 
 group :test do
+  gem "benchmark-ips", require: false
+  gem "memory_profiler", require: false
   gem "simplecov", require: false
   gem "simplecov-cobertura", require: false
   gem "simplecov-console", require: false
+  gem "stackprof", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,13 @@ GEM
       activemodel (= 8.0.0)
       activesupport (= 8.0.0)
       timeout (>= 0.4.0)
+    activerecord-session_store (2.1.0)
+      actionpack (>= 6.1)
+      activerecord (>= 6.1)
+      cgi (>= 0.3.6)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 4)
+      railties (>= 6.1)
     activestorage (8.0.0)
       actionpack (= 8.0.0)
       activejob (= 8.0.0)
@@ -90,6 +97,7 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     benchmark (0.4.0)
+    benchmark-ips (2.14.0)
     bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.18.4)
@@ -97,6 +105,7 @@ GEM
     brakeman (6.2.2)
       racc
     builder (3.3.0)
+    cgi (0.4.1)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -127,9 +136,11 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    memory_profiler (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.1)
     msgpack (1.7.3)
+    multi_json (1.15.0)
     mysql2 (0.5.6)
     net-imap (0.5.1)
       date
@@ -265,6 +276,7 @@ GEM
     sqlite3 (2.2.0-x86_64-darwin)
     sqlite3 (2.2.0-x86_64-linux-gnu)
     sqlite3 (2.2.0-x86_64-linux-musl)
+    stackprof (0.2.26)
     stringio (3.1.2)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -302,10 +314,13 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  activerecord-session_store
   appraisal
+  benchmark-ips
   bootsnap
   brakeman
   debug
+  memory_profiler
   mysql2
   pg
   propshaft
@@ -317,6 +332,7 @@ DEPENDENCIES
   simplecov-cobertura
   simplecov-console
   sqlite3
+  stackprof
   stored_session!
   web-console
 

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -9,6 +9,7 @@ gem "mysql2"
 gem "pg"
 gem "sqlite3"
 gem "bootsnap", require: false
+gem "activerecord-session_store"
 
 group :development, :test do
   gem "debug", platforms: [:mri, :windows], require: "debug/prelude"
@@ -23,9 +24,12 @@ group :development do
 end
 
 group :test do
+  gem "benchmark-ips", require: false
+  gem "memory_profiler", require: false
   gem "simplecov", require: false
   gem "simplecov-cobertura", require: false
   gem "simplecov-console", require: false
+  gem "stackprof", require: false
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -110,6 +110,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activerecord-session_store (2.1.0)
+      actionpack (>= 6.1)
+      activerecord (>= 6.1)
+      cgi (>= 0.3.6)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 4)
+      railties (>= 6.1)
     ansi (1.5.0)
     appraisal (2.5.0)
       bundler
@@ -118,6 +125,7 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     benchmark (0.4.0)
+    benchmark-ips (2.14.0)
     bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.18.4)
@@ -125,6 +133,7 @@ GEM
     brakeman (6.2.2)
       racc
     builder (3.3.0)
+    cgi (0.4.1)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -155,9 +164,11 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    memory_profiler (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.1)
     msgpack (1.7.3)
+    multi_json (1.15.0)
     mysql2 (0.5.6)
     net-imap (0.5.1)
       date
@@ -271,6 +282,7 @@ GEM
     sqlite3 (2.2.0-x86_64-darwin)
     sqlite3 (2.2.0-x86_64-linux-gnu)
     sqlite3 (2.2.0-x86_64-linux-musl)
+    stackprof (0.2.26)
     stringio (3.1.2)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -308,10 +320,13 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  activerecord-session_store
   appraisal
+  benchmark-ips
   bootsnap
   brakeman
   debug
+  memory_profiler
   mysql2
   pg
   propshaft
@@ -323,6 +338,7 @@ DEPENDENCIES
   simplecov-cobertura
   simplecov-console
   sqlite3
+  stackprof
   stored_session!
   web-console
 

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -9,6 +9,7 @@ gem "mysql2"
 gem "pg"
 gem "sqlite3"
 gem "bootsnap", require: false
+gem "activerecord-session_store"
 
 group :development, :test do
   gem "debug", platforms: [:mri, :windows], require: "debug/prelude"
@@ -23,9 +24,12 @@ group :development do
 end
 
 group :test do
+  gem "benchmark-ips", require: false
+  gem "memory_profiler", require: false
   gem "simplecov", require: false
   gem "simplecov-cobertura", require: false
   gem "simplecov-console", require: false
+  gem "stackprof", require: false
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_main.gemfile.lock
+++ b/gemfiles/rails_main.gemfile.lock
@@ -110,6 +110,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activerecord-session_store (2.1.0)
+      actionpack (>= 6.1)
+      activerecord (>= 6.1)
+      cgi (>= 0.3.6)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 4)
+      railties (>= 6.1)
     ansi (1.5.0)
     appraisal (2.5.0)
       bundler
@@ -118,6 +125,7 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     benchmark (0.4.0)
+    benchmark-ips (2.14.0)
     bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.18.4)
@@ -125,6 +133,7 @@ GEM
     brakeman (6.2.2)
       racc
     builder (3.3.0)
+    cgi (0.4.1)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -155,9 +164,11 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    memory_profiler (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.1)
     msgpack (1.7.3)
+    multi_json (1.15.0)
     mysql2 (0.5.6)
     net-imap (0.5.1)
       date
@@ -271,6 +282,7 @@ GEM
     sqlite3 (2.2.0-x86_64-darwin)
     sqlite3 (2.2.0-x86_64-linux-gnu)
     sqlite3 (2.2.0-x86_64-linux-musl)
+    stackprof (0.2.26)
     stringio (3.1.2)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -308,10 +320,13 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  activerecord-session_store
   appraisal
+  benchmark-ips
   bootsnap
   brakeman
   debug
+  memory_profiler
   mysql2
   pg
   propshaft
@@ -323,6 +338,7 @@ DEPENDENCIES
   simplecov-cobertura
   simplecov-console
   sqlite3
+  stackprof
   stored_session!
   web-console
 

--- a/test/benchmarks/comparison_benchmark.rb
+++ b/test/benchmarks/comparison_benchmark.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+require "minitest/benchmark"
+# require "action_dispatch/middleware/session/cookie_store"
+# require "action_dispatch/middleware/session/cache_store"
+require "action_dispatch/session/active_record_store"
+
+class SessionStoreComparisonBenchmark < Minitest::Benchmark
+  def self.bench_range
+    bench_exp 1, 1000
+  end
+
+  def bench_compare_write_session_active_record_session_store
+    5.times { StoredSession::Store.new(nil).find_session(nil, generate_sid) }
+
+    assert_performance_linear do |n|
+      n.times do
+        request = ActionDispatch::Request.new({ "rack.session.options" => {} })
+        store = ActionDispatch::Session::ActiveRecordStore.new(nil)
+        sid = generate_sid
+        store.send(:write_session, request, sid, { test: "data" * 1000 }, {})
+        store.send(:find_session, request, sid)
+      end
+    end
+  end
+
+  def bench_compare_write_session_stored_session_store
+    5.times { StoredSession::Store.new(nil).find_session(nil, generate_sid) }
+
+    assert_performance_linear do |n|
+      n.times do
+        request = ActionDispatch::Request.new({ "rack.session.options" => {} })
+        store = ActionDispatch::Session::StoredSessionStore.new(nil)
+        sid = generate_sid
+        store.send(:write_session, request, sid, { test: "data" * 1000 }, {})
+        store.send(:find_session, request, sid)
+      end
+    end
+  end
+
+  private
+    def generate_sid
+      sid = SecureRandom.hex(16)
+      sid.encode!(Encoding::UTF_8)
+      Rack::Session::SessionId.new(sid)
+    end
+end

--- a/test/dummy/db/migrate/20241110033446_add_sessions_table.rb
+++ b/test/dummy/db/migrate/20241110033446_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[8.0]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :updated_at
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_03_224006) do
+ActiveRecord::Schema[8.0].define(version: 2024_11_10_033446) do
+  create_table "sessions", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
+  end
+
   create_table "stored_sessions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
Initial results are disappointing:

```
bench_compare_write_session_stored_session_store         0.042947        0.318291        2.943109       29.941584       298.791184
bench_compare_write_session_active_record_session_store         0.009825        0.026233        0.110786        1.184807       12.211817
```

I'll need to get to the bottom of this before v1.0.